### PR TITLE
chore: show all blog posts in sidebar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -30,6 +30,8 @@ const config: Config = {
         },
         blog: {
           showReadingTime: true,
+          blogSidebarCount: 'ALL',
+          blogSidebarTitle: 'All Posts',
           editUrl: 'https://github.com/sourcetoad/open-source/tree/main',
         },
         theme: {


### PR DESCRIPTION
Once we had more than 5 blogs - only 5 showed. This shows all in sidebar. We can rethink once we get to like 30