### PR TITLE
chore: remove unused import

### DIFF
--- a/blog/2024/2024-08-28-redis-cluster-tls-laravel/index.mdx
+++ b/blog/2024/2024-08-28-redis-cluster-tls-laravel/index.mdx
@@ -269,7 +269,6 @@ declare(strict_types=1);
 namespace App\Support\RedisCluster;
 
 use Illuminate\Queue\RedisQueue;
-use Illuminate\Support\Facades\App;
 
 class RedisClusterQueue extends RedisQueue
 {


### PR DESCRIPTION
This import is unused after we removed app env detection (as its already padded in via the prefix)